### PR TITLE
Fix utils.getSiblingProject

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -5,7 +5,7 @@ exports.listProjects = ()->
   exports.getSiblingProjects()
 
 exports.getSiblingProjects = () ->
-  parent = path.dirname atom.project.path
+  parent = path.dirname path.join.apply null, atom.project.getPaths()
   paths = fs.readdirSync parent
   projects = []
   paths.forEach (name) ->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "project-switcher",
   "main": "./lib/project-switcher",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "activationEvents": "project-switcher:toggle",
   "description": "A short description of your package",
   "repository": "https://github.com/guileen/project-switcher",


### PR DESCRIPTION
As is the current code it doesn't work on atom v0.181.0.

Issue link #9